### PR TITLE
Update alpaca-trade-api version in Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-alpaca-trade-api = "==0.22"
+alpaca-trade-api = "==0.26"
 
 
 [dev-packages]


### PR DESCRIPTION
The version of `alpaca-trade-api` in the Pipfile is out of date.

Using the version currently specified in the Pipfile gives the following error when running the algorithm:
```TypeError: Cannot convert Float64Index to dtype datetime64[ns]; integer values are required for conversion```

That error was fixed in https://github.com/alpacahq/alpaca-trade-api-python/pull/54. 